### PR TITLE
refactor(endpoints): refactor operations on endpoints

### DIFF
--- a/konan_sdk/auth.py
+++ b/konan_sdk/auth.py
@@ -17,7 +17,7 @@ class KonanAuth:
         self.user: Optional[KonanUser] = None
 
     def login(self) -> KonanUser:
-        response = LoginEndpoint(self.auth_url).post(
+        response = LoginEndpoint(self.auth_url).request(
             KonanCredentials(self.email, self.password)
         )
 
@@ -32,7 +32,7 @@ class KonanAuth:
     def refresh_token(self) -> None:
         self._post_login_checks()
 
-        new_access_token = RefreshTokenEndpoint(self.auth_url).post(
+        new_access_token = RefreshTokenEndpoint(self.auth_url).request(
             self.user.refresh_token
         )
         self.user.set_access_token(new_access_token)

--- a/konan_sdk/endpoints/konan_endpoints.py
+++ b/konan_sdk/endpoints/konan_endpoints.py
@@ -5,6 +5,7 @@ from konan_sdk.endpoints.base_endpoint import (
     KonanBaseEndpoint,
     KonanBaseGenericDeploymentsEndpoint,
     KonanBaseDeploymentEndpoint,
+    KonanEndpointOperationEnum,
 )
 from konan_sdk.endpoints.interfaces import (
     KonanEndpointRequest,
@@ -38,6 +39,10 @@ class LoginEndpoint(KonanBaseEndpoint[KonanCredentials, KonanTokens]):
     def endpoint_path(self) -> str:
         return '/api/auth/login'
 
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
+
     def prepare_request(
         self, request_object: KonanCredentials
     ) -> KonanEndpointRequest:
@@ -64,6 +69,10 @@ class RefreshTokenEndpoint(KonanBaseEndpoint[str, str]):
     def endpoint_path(self) -> str:
         return '/api/auth/token/refresh'
 
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
+
     def prepare_request(self, request_object: str) -> KonanEndpointRequest:
         return KonanEndpointRequest(data={'refresh': request_object})
 
@@ -81,6 +90,10 @@ class PredictionEndpoint(
     @property
     def endpoint_path(self) -> str:
         return super().endpoint_path + '/predict'
+
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
 
     def prepare_request(
         self, request_object: Union[Dict, str]
@@ -106,6 +119,10 @@ class EvaluateEndpoint(
     @property
     def endpoint_path(self) -> str:
         return super().endpoint_path + '/evaluate'
+
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
 
     def prepare_request(
         self, request_object: KonanTimeWindow
@@ -153,6 +170,10 @@ class FeedbackEndpoint(
     def endpoint_path(self) -> str:
         return super().endpoint_path + '/predictions/feedback'
 
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
+
     def prepare_request(
         self, request_object: List[KonanFeedbackSubmission]
     ) -> KonanEndpointRequest:
@@ -194,6 +215,10 @@ class CreateDeploymentEndpoint(
     def name(self) -> str:
         return 'create-deployment'
 
+    @property
+    def endpoint_operation(self) -> KonanEndpointOperationEnum:
+        return KonanEndpointOperationEnum.POST
+
     def prepare_request(
         self, request_object: KonanDeploymentCreationRequest
     ) -> KonanEndpointRequest:
@@ -224,18 +249,3 @@ class CreateDeploymentEndpoint(
             ],
             endpoint_response.json['container_logs']
         )
-
-    # TODO: Currently, every endpoint class exposes BOTH .get() and .post()
-    # TODO: Perhaps it is better to explicitly support both or split them
-    def get(
-        self, request_object: KonanDeploymentCreationRequest
-    ) -> KonanDeploymentCreationResponse:
-        """Lists all deployments that this user has access to
-
-        :param request_object: endpoint request
-        :type request_object: KonanDeploymentCreationRequest
-        :raises NotImplementedError: Method not impelmented yet
-        :return: endpoint response
-        :rtype: KonanDeploymentCreationResponse
-        """
-        raise NotImplementedError()

--- a/konan_sdk/sdk.py
+++ b/konan_sdk/sdk.py
@@ -70,7 +70,7 @@ class KonanSDK:
 
         deployment_creation_response = CreateDeploymentEndpoint(
             self.api_url, user=self.auth.user
-        ).post(KonanDeploymentCreationRequest(
+        ).request(KonanDeploymentCreationRequest(
             name, docker_credentials, docker_image
         ))
         return deployment_creation_response
@@ -94,7 +94,7 @@ class KonanSDK:
         prediction = PredictionEndpoint(
             self.api_url,
             deployment_uuid=deployment_uuid, user=self.auth.user
-        ).post(input_data)
+        ).request(input_data)
         return prediction.uuid, prediction.output
 
     def evaluate(
@@ -121,7 +121,7 @@ class KonanSDK:
         model_metrics = EvaluateEndpoint(
             self.api_url,
             deployment_uuid=deployment_uuid, user=self.auth.user
-        ).post(KonanTimeWindow(start_time, end_time))
+        ).request(KonanTimeWindow(start_time, end_time))
 
         return model_metrics
 
@@ -147,5 +147,5 @@ class KonanSDK:
         feedbacks_result = FeedbackEndpoint(
             self.api_url,
             deployment_uuid=deployment_uuid, user=self.auth.user
-        ).post(feedbacks)
+        ).request(feedbacks)
         return feedbacks_result


### PR DESCRIPTION
Instead of a having specific `.get()` and `.post()` methods on each `*Endpoint` class that inherits from `KonanBaseEndpoint`, I refactored this logic to have the `KonanBaseEndpoint` class provide a single `.request()` method. In any `*Endpoint.request()` method, the appropriate `requests.get()`, `requests.post()`, `requests.delete()`, etc ... method is used based on the `*Endpoint.endpoint_operation` property that each `*Endpoint` class defines. 